### PR TITLE
[1/3] Support of HTTP, API Version and ClientId

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,15 @@ jdbc:ascendix:salesforce://;sessionId=uniqueIdAssociatedWithTheSession
 | _password_ |Login password associated with the specified username. <br>**Warning!** A password provided should contains your password and secret key joined in one string.|
 | _sessionId_ | Unique ID associated with this session. |
 | _loginDomain_ | Top-level domain for a login request. <br>Default value is _login.salesforce.com_. <br>Set _test.salesforce.com_ value to use sandbox. |
+| _https_ | Switch to use HTTP protocol instead of HTTPS <br>Default value is _true_|
+| _api_ | Api version to use. <br>Default value is _50.0_. <br>Set _test.salesforce.com_ value to use sandbox. |
+| _client_ | Client Id to use. <br>Default value is empty.  |
 
 
 ## Supported features
 1. Queries support native SOQL;
 2. Nested queries are supported;
-3. Request caching support on local drive. Canching supports 2 modes: global and session. Global mode means that the cached result will be accessible for all system users for certain JVM session. Session cache mode works for each Salesforce connection session separately. Both modes cache stores request result while JVM still running but no longer than for 1 hour. The cache mode can be enabled with a prefix of SOQL query. How to use:
+3. Request caching support on local drive. Caching supports 2 modes: global and session. Global mode means that the cached result will be accessible for all system users for certain JVM session. Session cache mode works for each Salesforce connection session separately. Both modes cache stores request result while JVM still running but no longer than for 1 hour. The cache mode can be enabled with a prefix of SOQL query. How to use:
   * Global cache mode:
   ```SQL
   CACHE GLOBAL SELECT Id, Name FROM Account

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <salesforce-soql-parser.version>2.0</salesforce-soql-parser.version>
-        <force-partner-api.version>43.0.0</force-partner-api.version>
+        <force-partner-api.version>50.0.0</force-partner-api.version>
         <mapdb.version>3.0.5</mapdb.version>
         <antlr.version>3.5.2</antlr.version>
         <opencsv.version>4.2</opencsv.version>
-        <xstream.version>1.4.10-java7</xstream.version>
+        <xstream.version>1.4.6</xstream.version>
         <org.apache.commons.io.version>2.4</org.apache.commons.io.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-collections4.version>4.1</commons-collections4.version>
 
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
@@ -37,7 +37,7 @@
         <mapdb.version>3.0.5</mapdb.version>
         <antlr.version>3.5.2</antlr.version>
         <opencsv.version>4.2</opencsv.version>
-        <xstream.version>1.4.6</xstream.version>
+        <xstream.version>1.4.8</xstream.version>
         <org.apache.commons.io.version>2.4</org.apache.commons.io.version>
     </properties>
 

--- a/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceConnection.java
+++ b/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceConnection.java
@@ -30,8 +30,10 @@ public class ForceConnection implements Connection {
     private final PartnerConnection partnerConnection;
     private final DatabaseMetaData metadata;
     private static final String SF_JDBC_DRIVER_NAME = "SF JDBC driver";
+    private static final Logger logger = Logger.getLogger(SF_JDBC_DRIVER_NAME);
 
     private Map connectionCache = new HashMap<>();
+    Properties clientInfo = new Properties();
 
     public ForceConnection(PartnerConnection partnerConnection) {
         this.partnerConnection = partnerConnection;
@@ -74,20 +76,19 @@ public class ForceConnection implements Connection {
 
     @Override
     public Statement createStatement() {
-        Logger.getLogger(SF_JDBC_DRIVER_NAME)
-                .info(Object.class.getEnclosingMethod().getName());
+        logger.info("[Conn] createStatement 1 IMPLEMENTED ");
         return null;
     }
 
     @Override
     public CallableStatement prepareCall(String sql) {
-        Logger.getLogger(SF_JDBC_DRIVER_NAME).info(Object.class.getEnclosingMethod().getName());
+        logger.info("[Conn] prepareCall NOT_IMPLEMENTED "+sql);
         return null;
     }
 
     @Override
     public String nativeSQL(String sql) {
-        Logger.getLogger(SF_JDBC_DRIVER_NAME).info(Object.class.getEnclosingMethod().getName());
+        logger.info("[Conn] nativeSQL NOT_IMPLEMENTED "+sql);
         return null;
     }
 
@@ -314,25 +315,26 @@ public class ForceConnection implements Connection {
     @Override
     public void setClientInfo(String name, String value) throws SQLClientInfoException {
         // TODO Auto-generated method stub
-
+        logger.info("[Conn] setClientInfo 1 IMPLEMENTED "+name+"="+value);
+        clientInfo.setProperty(name, value);
     }
 
     @Override
     public void setClientInfo(Properties properties) throws SQLClientInfoException {
-        // TODO Auto-generated method stub
-
+        logger.info("[Conn] setClientInfo 2 IMPLEMENTED properties<>");
+        properties.stringPropertyNames().forEach(propName -> clientInfo.setProperty(propName, properties.getProperty(propName)));
     }
 
     @Override
     public String getClientInfo(String name) throws SQLException {
-        // TODO Auto-generated method stub
-        return null;
+        logger.info("[Conn] getClientInfo 1 IMPLEMENTED for '"+name+"'");
+        return clientInfo.getProperty(name);
     }
 
     @Override
     public Properties getClientInfo() throws SQLException {
-        // TODO Auto-generated method stub
-        return null;
+        logger.info("[Conn] getClientInfo 2 IMPLEMENTED ");
+        return clientInfo;
     }
 
     @Override

--- a/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceConnectionInfo.java
+++ b/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceConnectionInfo.java
@@ -11,4 +11,8 @@ public class ForceConnectionInfo {
     private String password;
     private String sessionId;
     private Boolean sandbox;
+    private Boolean https = true;
+    private String apiVersion = ForceService.DEFAULT_API_VERSION;
+    private String loginDomain;
+    private String clientName;
 }

--- a/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceService.java
+++ b/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceService.java
@@ -8,6 +8,7 @@ import com.sforce.ws.ConnectorConfig;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
 import org.mapdb.HTreeMap;
@@ -19,11 +20,11 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class ForceService {
 
-    private static final String DEFAULT_LOGIN_DOMAIN = "login.salesforce.com";
+    public static final String DEFAULT_LOGIN_DOMAIN = "login.salesforce.com";
     private static final String SANDBOX_LOGIN_DOMAIN = "test.salesforce.com";
     private static final long CONNECTION_TIMEOUT = TimeUnit.SECONDS.toMillis(10);
     private static final long READ_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
-    private static final String DEFAULT_API_VERSION = "43.0";
+    public static final String DEFAULT_API_VERSION = "50.0";
     public static final int EXPIRE_AFTER_CREATE = 60;
     public static final int EXPIRE_STORE_SIZE = 16;
 
@@ -76,26 +77,32 @@ public class ForceService {
         ConnectorConfig partnerConfig = new ConnectorConfig();
         partnerConfig.setUsername(info.getUserName());
         partnerConfig.setPassword(info.getPassword());
-        if (info.getSandbox() != null) {
-            partnerConfig.setAuthEndpoint(buildAuthEndpoint(info.getSandbox()));
-            return Connector.newConnection(partnerConfig);
-        }
 
-        try {
-            partnerConfig.setAuthEndpoint(buildAuthEndpoint(false));
-            return Connector.newConnection(partnerConfig);
-        } catch (ConnectionException ce) {
-            partnerConfig.setAuthEndpoint(buildAuthEndpoint(true));
-            return Connector.newConnection(partnerConfig);
+        PartnerConnection connection;
+
+        if (info.getSandbox() != null) {
+            partnerConfig.setAuthEndpoint(buildAuthEndpoint(info));
+            connection = Connector.newConnection(partnerConfig);
+        } else {
+            try {
+                info.setSandbox(false);
+                partnerConfig.setAuthEndpoint(buildAuthEndpoint(info));
+                    connection = Connector.newConnection(partnerConfig);
+            } catch (ConnectionException ce) {
+                info.setSandbox(true);
+                partnerConfig.setAuthEndpoint(buildAuthEndpoint(info));
+                connection = Connector.newConnection(partnerConfig);
+            }
         }
+        if (connection != null && StringUtils.isNotBlank(info.getClientName())) {
+            connection.setCallOptions(info.getClientName(), null);
+        }
+        return connection;
     }
 
-    private static String buildAuthEndpoint(boolean sandbox) {
-        if (sandbox) {
-            return String.format("https://%s/services/Soap/u/%s", SANDBOX_LOGIN_DOMAIN, DEFAULT_API_VERSION);
-        } else {
-            return String.format("https://%s/services/Soap/u/%s", DEFAULT_LOGIN_DOMAIN, DEFAULT_API_VERSION);
-        }
-
+    private static String buildAuthEndpoint(ForceConnectionInfo info) {
+        String protocol = info.getHttps() ? "https" : "http";
+        String domain = info.getSandbox() ? SANDBOX_LOGIN_DOMAIN : info.getLoginDomain() != null ? info.getLoginDomain() : DEFAULT_LOGIN_DOMAIN;
+        return String.format("%s://%s/services/Soap/u/%s", protocol, domain, info.getApiVersion());
     }
 }

--- a/sf-jdbc-driver/src/test/java/com/ascendix/jdbc/salesforce/ForceDriverTest.java
+++ b/sf-jdbc-driver/src/test/java/com/ascendix/jdbc/salesforce/ForceDriverTest.java
@@ -8,9 +8,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ForceDriverTest {
 
@@ -49,10 +47,24 @@ public class ForceDriverTest {
     @Test
     public void testGetConnStringProperties_StandartUrlFormat() throws  IOException {
         Properties actuals = driver.getConnStringProperties("jdbc:ascendix:salesforce://test@test.ru:aaaa!aaa@login.salesforce.ru");
-        
-        assertEquals(2, actuals.size());
+
+        assertEquals(3, actuals.size());
         assertTrue(actuals.containsKey("user"));
         assertEquals("test@test.ru", actuals.getProperty("user"));
         assertEquals("aaaa!aaa", actuals.getProperty("password"));
+        assertEquals("login.salesforce.ru", actuals.getProperty("loginDomain"));
+    }
+
+    @Test
+    public void testGetConnStringProperties_StandartUrlFormatHttpsApi() throws  IOException {
+        Properties actuals = driver.getConnStringProperties("jdbc:ascendix:salesforce://test@test.ru:aaaa!aaa@login.salesforce.ru?https=false&api=48.0");
+
+        assertEquals(5, actuals.size());
+        assertTrue(actuals.containsKey("user"));
+        assertEquals("test@test.ru", actuals.getProperty("user"));
+        assertEquals("aaaa!aaa", actuals.getProperty("password"));
+        assertEquals("login.salesforce.ru", actuals.getProperty("loginDomain"));
+        assertEquals("false", actuals.getProperty("https"));
+        assertEquals("48.0", actuals.getProperty("api"));
     }
 }


### PR DESCRIPTION
1) Support of logging to custom domains
2) Support of HTTP insecure mode
3) Support of Client connection field
4) Bump to API version 50.0

Example URL:
jdbc:ascendix:salesforce://test@test.ru:aaaa!aaa@login.salesforce.ru?https=false&api=48.0&client=Internal